### PR TITLE
fix/steps-indicator

### DIFF
--- a/src/colors/accent.ts
+++ b/src/colors/accent.ts
@@ -2,7 +2,7 @@ import { colors } from './base'
 
 export const accent = {
   DEFAULT: colors.blue['700'],
-  dark: '#FFF',
+  dark: colors.blue['300'],
   alt: {
     DEFAULT: colors.grey['300'],
     dark: colors.grey['600']

--- a/src/components/StepsIndicator/Step.tsx
+++ b/src/components/StepsIndicator/Step.tsx
@@ -10,11 +10,14 @@ interface StepProps {
 const stepVariant = cva([
   'text-inherit',
   'fill-current',
-  'data-[selected=true]:text-primary-700',
+  'text-accent-alt',
   'dark:text-accent-alt-dark',
-  'dark:data-[selected=true]:text-primary-300',
   'hover:text-foreground-subtle',
-  'active:text-foreground-muted'
+  'dark:hover:text-foreground-subtle-dark',
+  'active:text-foreground-muted',
+  'dark:active:text-foreground-muted-dark',
+  'data-[selected=true]:text-accent',
+  'dark:data-[selected=true]:text-accent-dark'
 ])
 
 const Step = ({ selected, className }: StepProps) => {

--- a/src/components/StepsIndicator/Step.tsx
+++ b/src/components/StepsIndicator/Step.tsx
@@ -12,7 +12,9 @@ const stepVariant = cva([
   'fill-current',
   'data-[selected=true]:text-primary-700',
   'dark:text-accent-alt-dark',
-  'dark:data-[selected=true]:text-white'
+  'dark:data-[selected=true]:text-primary-300',
+  'hover:text-foreground-subtle',
+  'active:text-foreground-muted'
 ])
 
 const Step = ({ selected, className }: StepProps) => {

--- a/src/components/StepsIndicator/StepsIndicator.tsx
+++ b/src/components/StepsIndicator/StepsIndicator.tsx
@@ -26,7 +26,7 @@ const StepsIndicator = React.forwardRef<HTMLDivElement, StepsIndicatorProp>(
         return (
           <button
             key={`${i}-step-${name}`}
-            className="flex h-6 w-6 items-center justify-center m-0"
+            className="flex h-6 w-6 items-center justify-center m-0 outline-none"
             onClick={() => onClick?.(i)}
           >
             <Step selected={i === selectedIndex ? 'true' : 'false'} />

--- a/src/components/StepsIndicator/StepsIndicator.tsx
+++ b/src/components/StepsIndicator/StepsIndicator.tsx
@@ -13,37 +13,28 @@ const stepsVariant = cva([
 interface StepsIndicatorProp {
   selectedIndex?: number
   length?: number
-  className?: string
-  childClassName?: string
   props?: any
   name?: string
+  onClick?: (i: number) => void
 }
 
 const StepsIndicator = React.forwardRef<HTMLDivElement, StepsIndicatorProp>(
-  (
-    {
-      className,
-      childClassName,
-      name = '',
-      selectedIndex = 0,
-      length = 1,
-      props
-    },
-    ref
-  ) => {
+  ({ name = '', selectedIndex = 0, length = 1, onClick, props }, ref) => {
     const Steps = Array(length)
       .fill(null)
       .map((_, i) => {
         return (
-          <Step
+          <button
             key={`${i}-step-${name}`}
-            selected={i === selectedIndex ? 'true' : 'false'}
-            className={childClassName}
-          />
+            className="flex h-6 w-6 items-center justify-center m-0"
+            onClick={() => onClick?.(i)}
+          >
+            <Step selected={i === selectedIndex ? 'true' : 'false'} />
+          </button>
         )
       })
     return (
-      <div ref={ref} className={cn(stepsVariant(), className)} {...props}>
+      <div ref={ref} className={cn(stepsVariant())} {...props}>
         {Steps}
       </div>
     )

--- a/stories/StepsIndicator/Docs.mdx
+++ b/stories/StepsIndicator/Docs.mdx
@@ -8,7 +8,7 @@ import * as StepsStories from './StepsIndicator.stories'
 
 Used primarily to indicate the current step or inline page a user is on. We export both the individual `<Step/>` and `<StepsIndicator>`.
 
-## Default, with 10 pages on page 6
+## Default, with 10 pages on page 2
 
 <Canvas of={StepsStories.Default} />
 
@@ -34,16 +34,6 @@ The attributes that can be passed through are listed below.
       <td>1</td>
     </tr>
     <tr>
-      <td>className</td>
-      <td>`string`</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td>childClassName</td>
-      <td>`string`</td>
-      <td>-</td>
-    </tr>
-    <tr>
       <td>props</td>
       <td>`any`</td>
       <td>-</td>
@@ -51,11 +41,7 @@ The attributes that can be passed through are listed below.
   </tbody>
 </table>
 
-An array of length `length` contains `<Step>` components, the colour of which is controlled by the `selected` data attribute (`true | false`). By default we use `selectedIndex` to point to the component that requires this attribute to be true. For higher customisability, we also include the `className` and `childClassName`. These respectively refer to the `<div>` containing all the Steps, and the `<Step/>` themselves.
-
-For example, if you wanted the border of the `<div>` container to be grey, and the colour of the selected dot to be a large red:
-
-<Canvas of={StepsStories.Customised} />
+An array of length `length` contains `<Step>` components, the colour of which is controlled by the `selected` data attribute (`true | false`). We use `selectedIndex` to point to the component that requires this attribute to be true.
 
 ## Step
 

--- a/stories/StepsIndicator/Docs.mdx
+++ b/stories/StepsIndicator/Docs.mdx
@@ -34,6 +34,11 @@ The attributes that can be passed through are listed below.
       <td>1</td>
     </tr>
     <tr>
+      <td>onClick</td>
+      <td>`function`</td>
+      <td>-</td>
+    </tr>
+    <tr>
       <td>props</td>
       <td>`any`</td>
       <td>-</td>
@@ -42,6 +47,25 @@ The attributes that can be passed through are listed below.
 </table>
 
 An array of length `length` contains `<Step>` components, the colour of which is controlled by the `selected` data attribute (`true | false`). We use `selectedIndex` to point to the component that requires this attribute to be true.
+
+The `onClick` function has access to the index of the `<Step>` component that was just clicked and can use that to update the props passed to `<StepIndicator>`.
+
+## Example usage
+
+```ts
+export const StepsIndicatorDemo: React.FC = () => {
+  const [selectedIndex, setSelectedIndex] = useState<number>(1)
+  const onClick = (i: number) => setSelectedIndex(i)
+
+  return (
+    <StepsIndicator
+      length={10}
+      selectedIndex={selectedIndex}
+      onClick={onClick}
+    />
+  )
+}
+```
 
 ## Step
 
@@ -75,39 +99,5 @@ const Step = ({ idx, selected, className }: StepProps) => {
 
 export { Step, StepProps }
 
-
-```
-
-## Steps Indicator
-
-```ts
-import ProgressDefault from '@/assets/build/progressdefault.icon'
-import { cn } from '@/lib/utils'
-import { cva } from 'class-variance-authority'
-
-interface StepProps {
-  idx?: string
-  selected: 'true' | 'false'
-  className?: string
-}
-
-const stepVariant = cva([
-  'text-inherit',
-  'fill-current',
-  'data-[selected=true]:text-primary-700',
-  'dark:data-[selected=true]:text-white'
-])
-
-const Step = ({ idx, selected, className }: StepProps) => {
-  return (
-    <ProgressDefault
-      key={idx}
-      data-selected={selected}
-      className={cn(stepVariant(), className)}
-    />
-  )
-}
-
-export { Step, StepProps }
 
 ```

--- a/stories/StepsIndicator/StepsIndicator.example.tsx
+++ b/stories/StepsIndicator/StepsIndicator.example.tsx
@@ -1,0 +1,16 @@
+import { useState } from 'react'
+
+import { StepsIndicator } from '@/components/StepsIndicator'
+
+export const StepsIndicatorDemo: React.FC = () => {
+  const [selectedIndex, setSelectedIndex] = useState<number>(1)
+  const onClick = (i: number) => setSelectedIndex(i)
+
+  return (
+    <StepsIndicator
+      length={10}
+      selectedIndex={selectedIndex}
+      onClick={onClick}
+    />
+  )
+}

--- a/stories/StepsIndicator/StepsIndicator.stories.ts
+++ b/stories/StepsIndicator/StepsIndicator.stories.ts
@@ -24,12 +24,3 @@ export const Default: Story = {
     selectedIndex: 1
   }
 }
-export const Customised: Story = {
-  args: {
-    className: 'border border-4 p-5',
-    childClassName:
-      'data-[selected=true]:text-red-600 data-[selected=true]:h-5 data-[selected=true]:w-5',
-    length: 5,
-    selectedIndex: 1
-  }
-}

--- a/stories/StepsIndicator/StepsIndicator.stories.ts
+++ b/stories/StepsIndicator/StepsIndicator.stories.ts
@@ -1,18 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { StepsIndicator } from '@/components/StepsIndicator'
+import { StepsIndicatorDemo } from './StepsIndicator.example'
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {
   title: 'Components/Steps Indicator',
-  component: StepsIndicator,
+  component: StepsIndicatorDemo,
   parameters: {
     // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'centered'
   }
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
   // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
-} satisfies Meta<typeof StepsIndicator>
+} satisfies Meta<typeof StepsIndicatorDemo>
 
 export default meta
 type Story = StoryObj<typeof meta>

--- a/stories/StepsIndicator/StepsIndicator.stories.ts
+++ b/stories/StepsIndicator/StepsIndicator.stories.ts
@@ -18,9 +18,4 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 // More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
-export const Default: Story = {
-  args: {
-    length: 10,
-    selectedIndex: 1
-  }
-}
+export const Default: Story = {}


### PR DESCRIPTION
Adds 24px click area around steps. Removes the customized step indicator example. Added onClick handler to steps (seems like there should be a way to update the step through the click interaction)