### PR TITLE
fix/modal

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -2,8 +2,9 @@
 
 import * as React from 'react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
-import { CloseIcon } from '@/assets'
+import { cva, type VariantProps } from 'class-variance-authority'
 
+import { CloseIcon } from '@/assets'
 import { cn } from '@/lib/utils'
 
 const Modal = DialogPrimitive.Root
@@ -35,7 +36,7 @@ const ModalContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 shadow-lg bg-background dark:bg-foreground duration-200 sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-6 shadow-lg bg-background dark:bg-foreground duration-200 sm:rounded-lg',
         className
       )}
       {...props}
@@ -46,31 +47,41 @@ const ModalContent = React.forwardRef<
 ))
 ModalContent.displayName = DialogPrimitive.Content.displayName
 
+const headerVariants = cva(
+  [
+    'flex',
+    'items-center',
+    'justify-between',
+    'p-6',
+    'space-y-1.5',
+    'text-center',
+    'sm:text-left'
+  ],
+  {
+    variants: {
+      variant: {
+        form: ['pb-0']
+      }
+    }
+  }
+)
+
 const ModalHeader = ({
   className,
+  variant,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      'flex items-center justify-between p-6 space-y-1.5 text-center sm:text-left',
-      className
-    )}
-    {...props}
-  />
+}: React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof headerVariants>) => (
+  <div className={cn(headerVariants({ variant, className }))} {...props} />
 )
+
 ModalHeader.displayName = 'ModalHeader'
 
 const ModalFooter = ({
   className,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      'flex flex-col-reverse p-6 sm:flex-row sm:justify-start sm:space-x-2',
-      className
-    )}
-    {...props}
-  />
+  <div className={cn('flex flex-col p-6 pt-0 gap-2.5', className)} {...props} />
 )
 ModalFooter.displayName = 'ModalFooter'
 

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -55,13 +55,19 @@ const headerVariants = cva(
     'p-6',
     'space-y-1.5',
     'text-center',
-    'sm:text-left'
+    'sm:text-left',
+    'border-border-subtle',
+    'dark:border-border-subtle-dark'
   ],
   {
     variants: {
       variant: {
-        form: ['pb-0']
+        default: ['border-b'],
+        form: ['pb-0', 'border-b-0']
       }
+    },
+    defaultVariants: {
+      variant: 'default'
     }
   }
 )
@@ -119,17 +125,38 @@ const ModalClose = React.forwardRef<
   </DialogPrimitive.Close>
 ))
 
+const descriptionVariants = cva(
+  [
+    'text-sm',
+    'text-foreground-muted',
+    'border-border-subtle',
+    'dark:border-border-subtle-dark'
+  ],
+  {
+    variants: {
+      variant: {
+        default: ['border-b'],
+        form: ['border-b-0']
+      }
+    },
+    defaultVariants: {
+      variant: 'default'
+    }
+  }
+)
+
 const ModalDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description> &
+    VariantProps<typeof descriptionVariants>
+>(({ className, variant, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn('text-sm px-6 text-foreground-muted', className)}
+    className={cn(descriptionVariants({ variant, className }))}
     {...props}
   />
 ))
-ModalDescription.displayName = DialogPrimitive.Description.displayName
+ModalDescription.displayName = 'ModalDescription'
 
 export {
   Modal,

--- a/stories/Modal/Docs.mdx
+++ b/stories/Modal/Docs.mdx
@@ -1,6 +1,7 @@
 import { Canvas, Meta } from '@storybook/blocks'
 
 import * as ModalStories from './Modal.stories'
+import { ModalInfoDemo } from './ModalInfo.example'
 
 <Meta of={ModalStories} />
 
@@ -8,9 +9,17 @@ import * as ModalStories from './Modal.stories'
 
 A modal is a window that can be overlaid on the main window, which when opened, the main window is left partially visible and doesn't allow any user interaction.
 
-## Default
+## Info
 
-<Canvas of={ModalStories.Default} />
+<Canvas of={ModalStories.Info} />
+
+## Custom
+
+<Canvas of={ModalStories.Custom} />
+
+## Form
+
+<Canvas of={ModalStories.Form} />
 
 ## Attributes
 

--- a/stories/Modal/Modal.example.tsx
+++ b/stories/Modal/Modal.example.tsx
@@ -14,13 +14,11 @@ import { Button } from '@/components'
 export const ModalDemo = () => {
   return (
     <Modal>
-      <ModalTrigger>
-        <Button size="sm" variant="primary">
-          Open
-        </Button>
-      </ModalTrigger>
+      <Button size="sm" variant="primary" asChild>
+        <ModalTrigger>Open</ModalTrigger>
+      </Button>
       <ModalContent>
-        <ModalHeader>
+        <ModalHeader variant="form">
           <ModalTitle>Title</ModalTitle>
           <ModalClose />
         </ModalHeader>
@@ -30,21 +28,17 @@ export const ModalDemo = () => {
           </div>
         </ModalDescription>
         <ModalFooter>
-          <ModalCloseFooter className="w-full grid gap-2">
-            <Button
-              size="lg"
-              variant="primary"
-              className="w-full dark:bg-blue-300 dark:border-blue-300 dark:text-foreground"
-            >
+          <Button size="lg" variant="primary" asChild>
+            <ModalCloseFooter className="w-full grid gap-2">
               Close
-            </Button>
-            <div className="flex justify-center gap-4">
-              <div className="text-foreground-muted">Additional text line</div>
-              <div className="dark:text-primary-300 underline text-primary-600">
-                Additional text line
-              </div>
+            </ModalCloseFooter>
+          </Button>
+          <div className="flex justify-center gap-4">
+            <div className="text-foreground-muted">Additional text line</div>
+            <div className="dark:text-primary-300 underline text-primary-600">
+              Additional text line
             </div>
-          </ModalCloseFooter>
+          </div>
         </ModalFooter>
       </ModalContent>
     </Modal>

--- a/stories/Modal/Modal.example.tsx
+++ b/stories/Modal/Modal.example.tsx
@@ -32,16 +32,14 @@ export const ModalDemo = () => {
         <ModalFooter>
           <ModalCloseFooter className="w-full grid gap-2">
             <Button
-              size="sm"
+              size="lg"
               variant="primary"
               className="w-full dark:bg-blue-300 dark:border-blue-300 dark:text-foreground"
             >
               Close
             </Button>
             <div className="flex justify-center gap-4">
-              <div className="dark:text-foreground-muted">
-                Additional text line
-              </div>
+              <div className="text-foreground-muted">Additional text line</div>
               <div className="dark:text-primary-300 underline text-primary-600">
                 Additional text line
               </div>

--- a/stories/Modal/Modal.stories.ts
+++ b/stories/Modal/Modal.stories.ts
@@ -1,11 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { ModalDemo } from './Modal.example'
+import { ModalFormDemo } from './ModalForm.example'
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {
   title: 'Components/Modal',
-  component: ModalDemo,
+  component: ModalFormDemo,
   parameters: {
     // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'centered'
@@ -18,7 +18,7 @@ const meta = {
     }
   }
   // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
-} satisfies Meta<typeof ModalDemo>
+} satisfies Meta<typeof ModalFormDemo>
 
 export default meta
 type Story = StoryObj<typeof meta>

--- a/stories/Modal/Modal.stories.tsx
+++ b/stories/Modal/Modal.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { ModalInfoDemo } from './ModalInfo.example'
+import { ModalCustomDemo } from './ModalCustom.example'
 import { ModalFormDemo } from './ModalForm.example'
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
@@ -13,7 +15,7 @@ const meta = {
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
   argTypes: {
     className: {
-      controle: 'text',
+      control: 'text',
       description: 'Alter the className to change the style'
     }
   }
@@ -24,6 +26,15 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 // More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
-export const Default: Story = {
-  args: {}
+
+export const Info: Story = {
+  render: () => <ModalInfoDemo />
+}
+
+export const Custom: Story = {
+  render: () => <ModalCustomDemo />
+}
+
+export const Form: Story = {
+  render: () => <ModalFormDemo />
 }

--- a/stories/Modal/ModalCustom.example.tsx
+++ b/stories/Modal/ModalCustom.example.tsx
@@ -10,32 +10,30 @@ import {
 } from '@/components/Modal'
 import { Button } from '@/components'
 
-export const ModalCustomDemo = () => {
-  return (
-    <Modal>
-      <Button size="sm" variant="primary" asChild>
-        <ModalTrigger>Open</ModalTrigger>
-      </Button>
-      <ModalContent>
-        <ModalHeader>
-          <ModalTitle>Title</ModalTitle>
-          <ModalClose />
-        </ModalHeader>
-        <ModalDescription asChild>
-          <div>
-            <div className="bg-blue-50 dark:bg-blue-900 dark:text-foreground-inverse h-40 text-lg font-semibold items-center flex justify-center mb-6 mx-6">
-              Replace this component with your content
-            </div>
+export const ModalCustomDemo = () => (
+  <Modal>
+    <Button size="sm" variant="primary" asChild>
+      <ModalTrigger>Open</ModalTrigger>
+    </Button>
+    <ModalContent>
+      <ModalHeader>
+        <ModalTitle>Title</ModalTitle>
+        <ModalClose />
+      </ModalHeader>
+      <ModalDescription asChild>
+        <div>
+          <div className="bg-blue-50 dark:bg-blue-900 dark:text-foreground-inverse h-40 text-lg font-semibold items-center flex justify-center mb-6 mx-6">
+            Replace this component with your content
           </div>
-        </ModalDescription>
-        <ModalFooter>
-          <div className="flex justify-start gap-2.5">
-            <Button>Label</Button>
-            <Button variant="secondary">Label</Button>
-            <Button variant="tertiary">Label</Button>
-          </div>
-        </ModalFooter>
-      </ModalContent>
-    </Modal>
-  )
-}
+        </div>
+      </ModalDescription>
+      <ModalFooter>
+        <div className="flex justify-end gap-2.5">
+          <Button variant="tertiary">Label</Button>
+          <Button variant="secondary">Label</Button>
+          <Button>Label</Button>
+        </div>
+      </ModalFooter>
+    </ModalContent>
+  </Modal>
+)

--- a/stories/Modal/ModalCustom.example.tsx
+++ b/stories/Modal/ModalCustom.example.tsx
@@ -2,7 +2,6 @@ import {
   Modal,
   ModalContent,
   ModalClose,
-  ModalCloseFooter,
   ModalFooter,
   ModalDescription,
   ModalHeader,
@@ -11,35 +10,29 @@ import {
 } from '@/components/Modal'
 import { Button } from '@/components'
 
-export const ModalFormDemo = () => {
+export const ModalCustomDemo = () => {
   return (
     <Modal>
       <Button size="sm" variant="primary" asChild>
         <ModalTrigger>Open</ModalTrigger>
       </Button>
       <ModalContent>
-        <ModalHeader variant="form">
+        <ModalHeader>
           <ModalTitle>Title</ModalTitle>
           <ModalClose />
         </ModalHeader>
-        <ModalDescription variant="form" asChild>
+        <ModalDescription asChild>
           <div>
             <div className="bg-blue-50 dark:bg-blue-900 dark:text-foreground-inverse h-40 text-lg font-semibold items-center flex justify-center mb-6 mx-6">
-              Replace this component with your form
+              Replace this component with your content
             </div>
           </div>
         </ModalDescription>
         <ModalFooter>
-          <Button size="lg" variant="primary" asChild>
-            <ModalCloseFooter className="w-full grid gap-2">
-              Close
-            </ModalCloseFooter>
-          </Button>
-          <div className="flex justify-center gap-4">
-            <div className="text-foreground-muted">Additional text line</div>
-            <div className="dark:text-primary-300 underline text-primary-600">
-              Additional text line
-            </div>
+          <div className="flex justify-start gap-2.5">
+            <Button>Label</Button>
+            <Button variant="secondary">Label</Button>
+            <Button variant="tertiary">Label</Button>
           </div>
         </ModalFooter>
       </ModalContent>

--- a/stories/Modal/ModalForm.example.tsx
+++ b/stories/Modal/ModalForm.example.tsx
@@ -11,38 +11,36 @@ import {
 } from '@/components/Modal'
 import { Button } from '@/components'
 
-export const ModalFormDemo = () => {
-  return (
-    <Modal>
-      <Button size="sm" variant="primary" asChild>
-        <ModalTrigger>Open</ModalTrigger>
-      </Button>
-      <ModalContent>
-        <ModalHeader variant="form">
-          <ModalTitle>Title</ModalTitle>
-          <ModalClose />
-        </ModalHeader>
-        <ModalDescription variant="form" asChild>
-          <div>
-            <div className="bg-blue-50 dark:bg-blue-900 dark:text-foreground-inverse h-40 text-lg font-semibold items-center flex justify-center mb-6 mx-6">
-              Replace this component with your form
-            </div>
+export const ModalFormDemo = () => (
+  <Modal>
+    <Button size="sm" variant="primary" asChild>
+      <ModalTrigger>Open</ModalTrigger>
+    </Button>
+    <ModalContent>
+      <ModalHeader variant="form">
+        <ModalTitle>Title</ModalTitle>
+        <ModalClose />
+      </ModalHeader>
+      <ModalDescription variant="form" asChild>
+        <div>
+          <div className="bg-blue-50 dark:bg-blue-900 dark:text-foreground-inverse h-40 text-lg font-semibold items-center flex justify-center mb-6 mx-6">
+            Replace this component with your form
           </div>
-        </ModalDescription>
-        <ModalFooter>
-          <Button size="lg" variant="primary" asChild>
-            <ModalCloseFooter className="w-full grid gap-2">
-              Close
-            </ModalCloseFooter>
-          </Button>
-          <div className="flex justify-center gap-4">
-            <div className="text-foreground-muted">Additional text line</div>
-            <div className="dark:text-primary-300 underline text-primary-600">
-              Additional text line
-            </div>
+        </div>
+      </ModalDescription>
+      <ModalFooter>
+        <Button size="lg" variant="primary" asChild>
+          <ModalCloseFooter className="w-full grid gap-2">
+            Close
+          </ModalCloseFooter>
+        </Button>
+        <div className="flex justify-center gap-4">
+          <div className="text-foreground-muted">Additional text line</div>
+          <div className="dark:text-primary-300 underline text-primary-600">
+            Additional text line
           </div>
-        </ModalFooter>
-      </ModalContent>
-    </Modal>
-  )
-}
+        </div>
+      </ModalFooter>
+    </ModalContent>
+  </Modal>
+)

--- a/stories/Modal/ModalForm.example.tsx
+++ b/stories/Modal/ModalForm.example.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/components/Modal'
 import { Button } from '@/components'
 
-export const ModalDemo = () => {
+export const ModalFormDemo = () => {
   return (
     <Modal>
       <Button size="sm" variant="primary" asChild>

--- a/stories/Modal/ModalInfo.example.tsx
+++ b/stories/Modal/ModalInfo.example.tsx
@@ -1,0 +1,39 @@
+import {
+  Modal,
+  ModalContent,
+  ModalClose,
+  ModalFooter,
+  ModalDescription,
+  ModalHeader,
+  ModalTitle,
+  ModalTrigger
+} from '@/components/Modal'
+import { Button } from '@/components'
+
+export const ModalInfoDemo = () => {
+  return (
+    <Modal>
+      <Button size="sm" variant="primary" asChild>
+        <ModalTrigger>Open</ModalTrigger>
+      </Button>
+      <ModalContent>
+        <ModalHeader>
+          <ModalTitle>Title</ModalTitle>
+          <ModalClose />
+        </ModalHeader>
+        <ModalDescription className="h-40 text-foreground text-base" asChild>
+          <div>
+            <p className="mb-6 mx-6">Test</p>
+          </div>
+        </ModalDescription>
+        <ModalFooter>
+          <div className="flex justify-start gap-2.5">
+            <Button>Label</Button>
+            <Button variant="secondary">Label</Button>
+            <Button variant="tertiary">Label</Button>
+          </div>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/stories/Modal/ModalInfo.example.tsx
+++ b/stories/Modal/ModalInfo.example.tsx
@@ -10,30 +10,28 @@ import {
 } from '@/components/Modal'
 import { Button } from '@/components'
 
-export const ModalInfoDemo = () => {
-  return (
-    <Modal>
-      <Button size="sm" variant="primary" asChild>
-        <ModalTrigger>Open</ModalTrigger>
-      </Button>
-      <ModalContent>
-        <ModalHeader>
-          <ModalTitle>Title</ModalTitle>
-          <ModalClose />
-        </ModalHeader>
-        <ModalDescription className="h-40 text-foreground text-base" asChild>
-          <div>
-            <p className="mb-6 mx-6">Test</p>
-          </div>
-        </ModalDescription>
-        <ModalFooter>
-          <div className="flex justify-start gap-2.5">
-            <Button>Label</Button>
-            <Button variant="secondary">Label</Button>
-            <Button variant="tertiary">Label</Button>
-          </div>
-        </ModalFooter>
-      </ModalContent>
-    </Modal>
-  )
-}
+export const ModalInfoDemo = () => (
+  <Modal>
+    <Button size="sm" variant="primary" asChild>
+      <ModalTrigger>Open</ModalTrigger>
+    </Button>
+    <ModalContent>
+      <ModalHeader>
+        <ModalTitle>Title</ModalTitle>
+        <ModalClose />
+      </ModalHeader>
+      <ModalDescription className="h-40 text-foreground text-base" asChild>
+        <div>
+          <p className="mb-6 mx-6">Test</p>
+        </div>
+      </ModalDescription>
+      <ModalFooter>
+        <div className="flex justify-start gap-2.5">
+          <Button>Label</Button>
+          <Button variant="secondary">Label</Button>
+          <Button variant="tertiary">Label</Button>
+        </div>
+      </ModalFooter>
+    </ModalContent>
+  </Modal>
+)


### PR DESCRIPTION

1.   ~~There are a few variants provided in the Figma file. The one that has been implemented is close, but there are a couple of tweaks required - the button variant used in the footer should be lg~~
  * __done__
2.   Please double check the 'additional text line' font style. It should be text-base/font-normal and the colour should be foreground/muted
  * @nickzafiropulos this looks correct to me (16px/24px, rgb(107, 114, 128). Let me know if I'm wrong
    <img width="493" alt="image" src="https://github.com/nearform/quantum/assets/1139918/8acb1302-aba6-458a-9786-85b03b3d986a">
    <img width="1112" alt="image" src="https://github.com/nearform/quantum/assets/1139918/2821a9e5-653b-4ce9-b916-676a61fe2b11">
3.    The main content area should only have 24px padding around it - currently there is a little too much.
  * @nickzafiropulos This looks like it's already 24px. Am I looking at the right area?
    <img width="1121" alt="image" src="https://github.com/nearform/quantum/assets/1139918/324b9803-89cc-45fd-8f5f-095a67d8d8a8">

4.   Please add the other two modal variants, as in the Figma file ( info and custom )
  * __in progress__
5.  The above two variants include the option to change the footer variant to align the buttons left or right.
  * __in progress__