### PR TITLE
fix[294]: make label align prop optional

### DIFF
--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -40,7 +40,7 @@ interface LabelProps
   extends React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>,
     VariantProps<typeof labelVariants> {
   hintText?: string
-  align: 'left' | 'right'
+  align?: 'left' | 'right'
 }
 
 const Label = React.forwardRef<


### PR DESCRIPTION
Closes: #294

Makes the `align` property of the `Label` component optional.