### PR TITLE
fix: pagination console error, button text centering, docs update

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "dist/index.js",
   "exports": {
     ".": "./dist/index.js",
-    "./tailwind-plugin": "./dist/tailwind-plugin.js",
-    "./dist/colors": "./dist/colors/index.js"
+    "./tailwind-plugin": "./dist/tailwind-plugin.js"
   },
   "scripts": {
     "build": "tsup",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "exports": {
     ".": "./dist/index.js",
-    "./tailwind-plugin": "./dist/tailwind-plugin.js"
+    "./tailwind-plugin": "./dist/tailwind-plugin.js",
+    "./dist/colors": "./dist/colors/index.js"
   },
   "scripts": {
     "build": "tsup",

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
   [
-    'inline-flex items-center',
+    'inline-flex items-center justify-center',
     'rounded-lg',
     'transition-colors',
     'focus-visible:outline-none',

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -48,14 +48,17 @@ interface PaginationProps
     VariantProps<typeof PaginationVariants> {}
 
 export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
-  ({
-    className,
-    currentPage,
-    setCurrentPage,
-    numberOfItemsPerPage,
-    totalNumberOfFilteredItems,
-    ...props
-  }) => {
+  (
+    {
+      className,
+      currentPage,
+      setCurrentPage,
+      numberOfItemsPerPage,
+      totalNumberOfFilteredItems,
+      ...props
+    },
+    ref
+  ) => {
     const currentRowsLength = totalNumberOfFilteredItems ?? 0
 
     const totalPages = React.useMemo(() => {
@@ -113,7 +116,7 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
       if (currentPage !== 1) setCurrentPage(currentPage - 1)
     }
     return (
-      <nav className={cn(PaginationVariants(), className)} {...props}>
+      <nav className={cn(PaginationVariants(), className)} ref={ref} {...props}>
         <ul>
           <li className="hover:bg-background px-4 dark:hover:bg-background-dark rounded-sm">
             <button

--- a/stories/Modal/Docs.mdx
+++ b/stories/Modal/Docs.mdx
@@ -299,7 +299,7 @@ const ModalClose = React.forwardRef<
     {...props}
   >
     <div className="text-foreground dark:text-foreground-inverse">
-      <CloseIcon className="w-5 h-5" strokeWidth={0.833} />
+      <BsXLg className="w-5 h-5" strokeWidth={0.833} />
     </div>
     <span className="sr-only">Close</span>
   </DialogPrimitive.Close>


### PR DESCRIPTION
- fixed console error in Pagination component complaining about a forgot ref
- updated Modal docs to remove non-existing component `<CloseIcon />` mention
- centers text on Button